### PR TITLE
Update prettier and default extensions

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,28 +2,33 @@ const prettier = require("prettier");
 const fs = require("fs");
 const path = require("path");
 
+const DEFAULT_EXTENSIONS = [
+  ".js",
+  ".jsx",
+  ".ts",
+  ".tsx",
+  ".css",
+  ".less",
+  ".scss",
+  ".sass"
+];
+
+const DEFAULT_ENCODING = "utf-8";
+
 module.exports = class PrettierPlugin {
   constructor(options) {
     options = options || {};
 
     // Encoding to use when reading / writing files
-    this.encoding = options.encoding || "utf-8";
+    this.encoding = options.encoding || DEFAULT_ENCODING;
+    delete options.encoding;
 
     // Only process these files
-    this.extensions = options.extensions || [ ".js", ".jsx" ];
+    this.extensions = options.extensions || DEFAULT_EXTENSIONS;
+    delete options.extensions;
 
     // Override Prettier options if any are specified
-    this.prettierOptions = {
-      printWidth: options.printWidth,
-      tabWidth: options.tabWidth,
-      useTabs: options.useTabs,
-      semi: options.semi,
-      singleQuote: options.singleQuote,
-      trailingComma: options.trailingComma,
-      bracketSpacing: options.bracketSpacing,
-      jsxBracketSameLine: options.jsxBracketSameLine,
-      parser: options.parser
-    };
+    this.prettierOptions = options;
   }
 
   apply(compiler) {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/hawkins/prettier-webpack-plugin#readme",
   "dependencies": {
-    "prettier": "^1.3.1"
+    "prettier": "^1.4.4"
   },
   "devDependencies": {
     "jest": "^20.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2031,7 +2031,7 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.3.1:
+prettier@^1.4.4:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.4.4.tgz#a8d1447b14c9bf67e6d420dcadd10fb9a4fad65a"
 


### PR DESCRIPTION
Now defaults to

```
  ".js",
  ".jsx",
  ".ts",
  ".tsx",
  ".css",
  ".less",
  ".scss",
  ".sass"
```

However, a couple things I'm unclear of: 

- Is GraphQL fully supported? Does it have its own file extension?
- Would this be a major, minor, or patch version change?