### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: node_js

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,5 @@ language: node_js
 node_js:
   - node
   - 7
-  - 6
-  - 5
-  - 4
 script:
-  - npm run travis:test
+  - npm run test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,8 @@
 language: node_js
+node_js:
+  - node
+  - 7
+  - 6
+  - 5
+  - 4
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ node_js:
   - 6
   - 5
   - 4
-  
+script:
+  - npm run travis:test

--- a/package.json
+++ b/package.json
@@ -5,23 +5,18 @@
   "main": "index.js",
   "scripts": {
     "test": "jest",
+    "travis:test": "node --harmony ./node_modules/.bin/jest",
     "ac:add": "all-contributors add",
     "ac:generate": "all-contributors generate"
   },
   "jest": {
-    "testPathIgnorePatterns": [
-      "sample-code.js"
-    ]
+    "testPathIgnorePatterns": ["sample-code.js"]
   },
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/hawkins/prettier-webpack-plugin.git"
   },
-  "keywords": [
-    "prettier",
-    "webpack",
-    "plugin"
-  ],
+  "keywords": ["prettier", "webpack", "plugin"],
   "author": "Josh Hawkins <hawkinswritescode@gmail.com>",
   "license": "MIT",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "index.js",
   "scripts": {
     "test": "jest",
-    "travis:test": "node --harmony ./node_modules/jest/bin/jest.js",
     "ac:add": "all-contributors add",
     "ac:generate": "all-contributors generate"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "jest",
-    "travis:test": "node --harmony ./node_modules/.bin/jest",
+    "travis:test": "node --harmony ./node_modules/jest/bin/jest.js",
     "ac:add": "all-contributors add",
     "ac:generate": "all-contributors generate"
   },


### PR DESCRIPTION
Just runs tests on latest node version and node v7 latest.

Wanted to have it run on older versions too, to better ensure compatibility with older versions, but couldn't get older tests to run due to use of `async/await`. So for now, this will do to set up greenkeeper, I think