### PR TITLE
add `filepath` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ module.exports = class PrettierPlugin {
           if (err) {
               return reject(err);
           }
-          const prettierSource = prettier.format(source, this.prettierOptions);
+          const prettierSource = prettier.format(source, Object.assign({}, this.prettierOptions, { filepath }));
           if (prettierSource !== source) {
             fs.writeFile(filepath, prettierSource, this.encoding, err => {
               if (err) {


### PR DESCRIPTION
I tried using [prettier-plugin-elm](https://github.com/gicentre/prettier-plugin-elm) with `pluginSearchDirs` and `plugins` options.

```
  plugins: [
    new PrettierPlugin({
      extensions: [ ".ts", ".tsx", ".elm" ],
      pluginSearchDirs: [ path.resolve(__dirname, "node_modules") ],
      plugins: [ "prettier-plugin-elm" ]
    })
  ],
```

https://prettier.io/docs/en/plugins.html

However, since there is no `filepath` option, the prettier could not determine parser from filepath. (The default parser `babylon` was selected)

https://github.com/prettier/prettier/blob/1.14.2/src/main/options.js#L38-L40

Please consider merge so that parser of elm can be specified from `filepath`.